### PR TITLE
Fix for "Unable to invoke withConsumerListeners() on ConfigurableChannel" Issue #18

### DIFF
--- a/src/main/java/net/jodah/lyra/internal/ChannelHandler.java
+++ b/src/main/java/net/jodah/lyra/internal/ChannelHandler.java
@@ -28,7 +28,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 
 /**
  * Handles channel method invocations.
- * 
+ *
  * @author Jonathan Halterman
  */
 public class ChannelHandler extends RetryableResource implements InvocationHandler {
@@ -90,13 +90,13 @@ public class ChannelHandler extends RetryableResource implements InvocationHandl
 
   @Override
   public Object invoke(Object ignored, final Method method, final Object[] args) throws Throwable {
-    if (closed && Channel.class.equals(method.getDeclaringClass()))
+    if (closed && method.getDeclaringClass().isAssignableFrom(Channel.class))
       throw new AlreadyClosedException("Attempt to use closed channel", proxy);
 
     Callable<Object> callable = new Callable<Object>() {
       @Override
       public Object call() throws Exception {
-        if (ChannelConfig.class.equals(method.getDeclaringClass()))
+        if (method.getDeclaringClass().isAssignableFrom(ChannelConfig.class))
           return Reflection.invoke(config, method, args);
 
         String methodName = method.getName();
@@ -182,7 +182,7 @@ public class ChannelHandler extends RetryableResource implements InvocationHandl
 
   /**
    * Atomically recovers the channel.
-   * 
+   *
    * @throws Exception when recovery fails due to a connection closure
    */
   synchronized void recoverChannel(boolean returnOnFailedRecovery) throws Exception {
@@ -261,7 +261,7 @@ public class ChannelHandler extends RetryableResource implements InvocationHandl
   /**
    * Recovers the channel's consumers to given {@code channel}. If a consumer recovery fails due to
    * a channel closure, then we will not attempt to recover that consumer again.
-   * 
+   *
    * @throws Exception when recovery fails due to a resource closure
    */
   private void recoverConsumers(Map<String, Invocation> consumers) throws Exception {

--- a/src/main/java/net/jodah/lyra/internal/ConnectionHandler.java
+++ b/src/main/java/net/jodah/lyra/internal/ConnectionHandler.java
@@ -28,7 +28,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 
 /**
  * Handles connection method invocations.
- * 
+ *
  * @author Jonathan Halterman
  */
 public class ConnectionHandler extends RetryableResource implements InvocationHandler {
@@ -125,8 +125,8 @@ public class ConnectionHandler extends RetryableResource implements InvocationHa
             return channelProxy;
           }
 
-          return Reflection.invoke(
-              ConnectionConfig.class.equals(method.getDeclaringClass()) ? config : delegate,
+          return Reflection.invoke(method.getDeclaringClass().
+                  isAssignableFrom(ConnectionConfig.class) ? config : delegate,
               method, args);
         }
 


### PR DESCRIPTION
The ConnectionHandler and ChannelHandler classes are proxying requests on Connection and Channel respectively.
But they are checking for exact matches of method's class name and expected classname (Connection, ChannelConfig, etc). This will fault when inheritance is used in classes.

Instead of exact match check for isAssignableFrom().
