### PR TITLE
Adds "Recovered" log line for successful channel recovery.

### DIFF
--- a/src/main/java/net/jodah/lyra/internal/ChannelHandler.java
+++ b/src/main/java/net/jodah/lyra/internal/ChannelHandler.java
@@ -212,6 +212,7 @@ public class ChannelHandler extends RetryableResource implements InvocationHandl
           previousMaxDeliveryTag = maxDeliveryTag;
           Channel channel = connectionHandler.createChannel(delegate.getChannelNumber());
           migrateConfiguration(channel);
+          log.info("Recovered {} ", ChannelHandler.this);
           return channel;
         }
       }, config.getChannelRecoveryPolicy(), recoveryStats, true, false);


### PR DESCRIPTION
This is not a terribly important pull, but definitely a nice-to-have.  

In the [ConnectionHandler recovery](https://github.com/jhalterman/lyra/blob/master/src/main/java/net/jodah/lyra/internal/ConnectionHandler.java#L218), after a channel is successfully recovered there is a log line to state it was recovered. This log has great utility in confirming that the connection was recovered, however the [ChannelHander recovery](https://github.com/jhalterman/lyra/blob/master/src/main/java/net/jodah/lyra/internal/ChannelHandler.java#L211) does not have a similar line.

This change will take this log snippet: 

```
20:00:54 ERROR [AMQP Connection 192.168.0.200:5000] Channel channel-1 on cxn-1 was closed unexpectedly
20:00:54 ERROR [AMQP Connection 192.168.0.200:5000] Connection cxn-1 was closed unexpectedly
20:00:54 INFO [lyra-recovery-2] Recovering connection cxn-1 to [Lcom.rabbitmq.client.Address;@271429c8
20:00:54 INFO [lyra-recovery-2] Recovered connection cxn-1 to amqp://192.168.0.200:5000/
20:00:54 INFO [lyra-recovery-2] Recovering channel-1 on cxn-1
```

and add one more line:  

```
20:00:54 INFO [lyra-recovery-2] Recovered channel-1 on cxn-1
```
