### PR TITLE
fix: null safe retryStats

### DIFF
--- a/src/main/java/net/jodah/lyra/internal/RetryableResource.java
+++ b/src/main/java/net/jodah/lyra/internal/RetryableResource.java
@@ -67,6 +67,9 @@ abstract class RetryableResource {
             long startTime = System.nanoTime();
 
             if (retryable) {
+        	  if (retryStats == null) {
+        		retryStats = new RecurringStats(recurringPolicy);
+        	  }
               // Wait for pending recovery
               if (sse != null) {
                 if (recurringPolicy.getMaxDuration() == null)
@@ -78,8 +81,6 @@ abstract class RetryableResource {
               }
 
               // Continue retries
-              if (retryStats == null)
-                retryStats = new RecurringStats(recurringPolicy);
               retryStats.incrementAttempts();
               if (!retryStats.isPolicyExceeded()) {
                 long remainingWaitTime =


### PR DESCRIPTION
When connection lost on channel publish, reconnection fails by a NullPointerException on circuit.await(retryStats.getMaxWaitTime(), cause retryStats is not initialized.

Please check the commits

Thanks!
