### PR TITLE
Allow backoff interval durations to use different units

### DIFF
--- a/src/main/java/net/jodah/lyra/internal/RecurringPolicy.java
+++ b/src/main/java/net/jodah/lyra/internal/RecurringPolicy.java
@@ -103,7 +103,7 @@ public abstract class RecurringPolicy<T extends RecurringPolicy<T>> {
     Assert.notNull(interval, "interval");
     Assert.notNull(maxInterval, "maxInterval");
     Assert.isTrue(interval.length > 0, "The interval must be greater than 0");
-    Assert.isTrue(interval.length < maxInterval.length,
+    Assert.isTrue(interval.toNanoseconds() < maxInterval.toNanoseconds(),
         "The interval must be less than the maxInterval");
     Assert.isTrue(intervalMultiplier > 1, "The intervalMultiplier must be greater than 1");
     this.interval = interval;

--- a/src/test/java/net/jodah/lyra/internal/RecurringPolicyTest.java
+++ b/src/test/java/net/jodah/lyra/internal/RecurringPolicyTest.java
@@ -1,0 +1,13 @@
+package net.jodah.lyra.internal;
+
+import net.jodah.lyra.util.Duration;
+import org.testng.annotations.Test;
+
+@Test
+public class RecurringPolicyTest  extends AbstractFunctionalTest {
+
+    public void shouldAllowDifferentUnitsForIntervalDurations() throws Throwable {
+        RecurringPolicy recurringPolicy = new RecurringPolicy(){};
+        recurringPolicy.withBackoff(Duration.millis(100), Duration.days(1));
+    }
+}


### PR DESCRIPTION
The RecurringPolicy asserted that the size of the max interval is greater than the initial interval and didn't take into account the units.

This change compares the nanoseconds of the 2 durations.