### PR TITLE
proposed changes for "Lyra recover mechanism prevent from the JVM to shutdown"

### DIFF
--- a/src/main/java/net/jodah/lyra/ConnectionOptions.java
+++ b/src/main/java/net/jodah/lyra/ConnectionOptions.java
@@ -34,6 +34,7 @@ public class ConnectionOptions {
 
   public ConnectionOptions() {
     factory = new ConnectionFactory();
+    factory.setAutomaticRecoveryEnabled(false);
   }
 
   /**

--- a/src/main/java/net/jodah/lyra/Connections.java
+++ b/src/main/java/net/jodah/lyra/Connections.java
@@ -109,7 +109,7 @@ public final class Connections {
       throws IOException, TimeoutException {
     Assert.notNull(options, "options");
     Assert.notNull(config, "config");
-    Assert.isTrue(!options.getConnectionFactory().isAutomaticRecoveryEnabled(),
+    Assert.isFalse(options.getConnectionFactory().isAutomaticRecoveryEnabled(),
             "RabbitMQ Automatic Recovery cannot be enabled");
     Assert.notNull(classLoader, CLASS_LOADER_PARAMETER_NAME);
     ConnectionHandler handler = new ConnectionHandler(options.copy(), new Config(config), classLoader);

--- a/src/main/java/net/jodah/lyra/Connections.java
+++ b/src/main/java/net/jodah/lyra/Connections.java
@@ -109,6 +109,8 @@ public final class Connections {
       throws IOException, TimeoutException {
     Assert.notNull(options, "options");
     Assert.notNull(config, "config");
+    Assert.isTrue(!options.getConnectionFactory().isAutomaticRecoveryEnabled(),
+            "RabbitMQ Automatic Recovery cannot be enabled");
     Assert.notNull(classLoader, CLASS_LOADER_PARAMETER_NAME);
     ConnectionHandler handler = new ConnectionHandler(options.copy(), new Config(config), classLoader);
     ConfigurableConnection proxy = (ConfigurableConnection) Proxy.newProxyInstance(

--- a/src/main/java/net/jodah/lyra/internal/util/Assert.java
+++ b/src/main/java/net/jodah/lyra/internal/util/Assert.java
@@ -7,6 +7,14 @@ public final class Assert {
   private Assert() {
   }
 
+  public static void isFalse(boolean expression) {
+    isTrue(!expression);
+  }
+
+  public static void isFalse(boolean expression, String errorMessageFormat, Object... args) {
+    isTrue(!expression, errorMessageFormat, args);
+  }
+
   public static void isTrue(boolean expression) {
     if (!expression)
       throw new IllegalArgumentException();

--- a/src/main/java/net/jodah/lyra/internal/util/concurrent/NamedThreadFactory.java
+++ b/src/main/java/net/jodah/lyra/internal/util/concurrent/NamedThreadFactory.java
@@ -22,6 +22,8 @@ public class NamedThreadFactory implements ThreadFactory {
 
   @Override
   public Thread newThread(Runnable r) {
-    return new Thread(r, String.format(nameFormat, threadNumber.getAndIncrement()));
+    Thread t = new Thread(r, String.format(nameFormat, threadNumber.getAndIncrement()));
+    t.setDaemon(true);
+    return t;
   }
 }


### PR DESCRIPTION
I've changed `NamedThreadFactory` to create daemon threads, so that the JVM won't hang if the executor is not shutdown state.
+ The recovery is manged by Lyra, so I've disabled the `automaticRecovery` flag in the `ConectionFactory`
